### PR TITLE
Tests fail in the latest release

### DIFF
--- a/t/02_regression.t
+++ b/t/02_regression.t
@@ -42,7 +42,10 @@ $nt->credentials('barney','rubble');
 $r = $nt->user_timeline;
 like $request->header('Authorization'), qr/^Basic /, 'Basic Auth header';
 
-{
+SKIP: {
+    eval 'use Net::OAuth 0.25';
+    skip "Net::OAuth >= 0.25 required for this test", 1 if $@;
+
     # NTL fails on methods using HTTP DELETE with OAuth (reported 2011-03-28)
     my $nt = Net::Twitter::Lite->new(
         consumer_key        => 'key',

--- a/t/unicode.t
+++ b/t/unicode.t
@@ -27,9 +27,9 @@ sub raw_sent_status {
 sub sent_status { decode_utf8 raw_sent_status() }
 
 my $nt = Net::Twitter::Lite->new(
-    consumer_key    => 'key',
-    consumer_secret => 'secret',
-    ua              => $ua,
+    username         => 'key',
+    password         => 'secret',
+    ua               => $ua,
     legacy_lists_api => 0,
 );
 $nt->access_token('token');


### PR DESCRIPTION
Perl 5.16.2 output:

```
Manifying blib/man3/Net::Twitter::Lite::API::V1.3
PERL_DL_NONLAZY=1 /opt/perl5/perls/perl-5.16.2/bin/perl "-MExtUtils::Command::MM" "-e" "test_harness(0, 'blib/lib', 'blib/arch')" t/*.t
t/00-compile.t ............ ok
# Testing Net::Twitter::Lite 0.12000, Perl 5.016002, /opt/perl5/perls/perl-5.16.2/bin/perl
t/00_load.t ............... ok
t/01_basic.t .............. ok

#   Failed test 'HTTP DELETE'
#   at t/02_regression.t line 55.
# Looks like you failed 1 test of 4.
t/02_regression.t ......... 
Dubious, test returned 1 (wstat 256, 0x100)
```

...and here:

```
t/release-pod-coverage.t .. skipped: these tests are for release candidate testing
t/release-pod-syntax.t .... skipped: these tests are for release candidate testing
t/ssl.t ................... ok
Can't call method "content" on an undefined value at t/unicode.t line 22.
# Looks like you planned 9 tests but ran 1.
# Looks like your test exited with 2 just after 1.
t/unicode.t ............... 
Dubious, test returned 2 (wstat 512, 0x200)
Failed 8/9 subtests 
```

Summary:

```
Test Summary Report
-------------------
t/02_regression.t       (Wstat: 256 Tests: 4 Failed: 1)
  Failed test:  4
  Non-zero exit status: 1
t/unicode.t             (Wstat: 512 Tests: 1 Failed: 0)
  Non-zero exit status: 2
  Parse errors: Bad plan.  You planned 9 tests but ran 1.
Files=12, Tests=415,  1 wallclock secs ( 0.08 usr  0.02 sys +  0.74 cusr  0.11 csys =  0.95 CPU)
Result: FAIL
Failed 2/12 test programs. 1/415 subtests failed.
make: *** [test_dynamic] Error 2
```
