### PR TITLE
https instead of http

### DIFF
--- a/lib/Net/Twitter/Lite/WithAPIv1_1.pm
+++ b/lib/Net/Twitter/Lite/WithAPIv1_1.pm
@@ -10,10 +10,10 @@ Net::Twitter::Lite::WithAPIv1_1 - A perl API library for Twitter's API v1.1
 =cut
 
 sub twitter_api_def_from           () { 'Net::Twitter::Lite::API::V1_1' }
-sub _default_api_url               () { 'http://api.twitter.com/1.1'    }
-sub _default_searchapiurl          () { 'http://search.twitter.com'     }
-sub _default_search_trends_api_url () { 'http://api.twitter.com/1.1'    }
-sub _default_lists_api_url         () { 'http://api.twitter.com/1.1'    }
+sub _default_api_url               () { 'https://api.twitter.com/1.1'    }
+sub _default_searchapiurl          () { 'https://search.twitter.com'     }
+sub _default_search_trends_api_url () { 'https://api.twitter.com/1.1'    }
+sub _default_lists_api_url         () { 'https://api.twitter.com/1.1'    }
 
 sub new {
     my $class = shift;


### PR DESCRIPTION
for https://dev.twitter.com/discussions/24239

Restricting api.twitter.com to SSL/TLS traffic
