### PR TITLE
Allow specifying optional arguments.

### DIFF
--- a/lib/Net/Twitter/Lite.pm
+++ b/lib/Net/Twitter/Lite.pm
@@ -446,7 +446,7 @@ sub build_api_methods {
                 # just in case it's included where it shouldn't be:
                 delete $args->{-legacy_lists_api};
 
-                croak sprintf "$name expected %d args", scalar @$arg_names if @_ > @$arg_names;
+                croak sprintf "$name expected %d args", scalar @$arg_names if @_ < @$arg_names;
 
                 # promote positional args to named args
                 for ( my $i = 0; @_; ++$i ) {


### PR DESCRIPTION
(Sorry if I've misunderstood this, but I just tried to call `verify_credentials(skip_status => 1)` and received an error caused by this.)

@$arg_names is the number of required parameters, so we want to error if we have fewer than that, not more.
